### PR TITLE
Add Linux platform to Gemfile.lock ✅

### DIFF
--- a/android/Gemfile.lock
+++ b/android/Gemfile.lock
@@ -220,6 +220,7 @@ GEM
 
 PLATFORMS
   x64-mingw-ucrt
+  x86_64-linux
 
 DEPENDENCIES
   fastlane


### PR DESCRIPTION
made workflow running on a Linux-based machine (x86_64-linux)  by replacement (x64-mingw-ucrt) platform (Windows).